### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:alpine as builder
 RUN apk add build-base
 
 COPY . /src
-WORKDIR /src
+WORKDIR /src/cmd/helpbot
 ENV CGO_ENABLED 1
 RUN go mod download
 RUN go install -ldflags '-s -w -extldflags "-static"' .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,4 @@ services:
     volumes: 
       - .:/code
     working_dir: /code
+    command: ["-config=.helpbotrc"]


### PR DESCRIPTION
Running `docker-compose up` is failing.
```
...
Step 9/12 : COPY --from=builder /go/bin/helpbot /go/bin/helpbot
ERROR: Service 'bot' failed to build : COPY failed: stat go/bin/helpbot: file does not exist
```

The error seems to be caused due to the wrong workdir path in the builder image. Changing it to the following solves the problem:
```
WORKDIR /src/cmd/helpbot
```

I also added the `cmd` instruction to allow users to setup the configuration file in the docker-compose.